### PR TITLE
Dev

### DIFF
--- a/src/Mx.NET.SDK.Core/Domain/ESDTAmount.cs
+++ b/src/Mx.NET.SDK.Core/Domain/ESDTAmount.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Mx.NET.SDK.Core.Domain.Exceptions;
@@ -167,7 +168,7 @@ namespace Mx.NET.SDK.Core.Domain
         /// <returns></returns>
         public double ToDouble()
         {
-            return double.Parse(ToDenominated());
+            return double.Parse(ToDenominated(), CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/Mx.NET.SDK.Core/Mx.NET.SDK.Core.csproj
+++ b/src/Mx.NET.SDK.Core/Mx.NET.SDK.Core.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/RemarkableTools/Mx.NET.SDK/tree/main/src/Mx.NET.SDK.Core</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <Company>Remarkable Tools</Company>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Title>RemarkableTools.Mx.Core</Title>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
ESDTAmount ToDouble() bug resolved:

Explanation:
- ToDenominated() is returning a string with dot [.] as decimal separator
- So, when is converted to double needs CutureInfo.InvariantCulture to convert the double with dot [.] always
- if PC operation system uses comma [,] as separator double.Parse converts with comma [,] but if InvariantCulture is specified will convert with the dot